### PR TITLE
Add Dependabot auto update pr and bump python from 3.10.8 to 3.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.8
+FROM python:3.11.0
 RUN apt update && apt install -y cron
 COPY . /app
 COPY crontab /etc/cron.d/sn-daily


### PR DESCRIPTION
- Bump python from 3.10.8 to 3.11.0
- Add auto update docker image to Dependabot
